### PR TITLE
Expose Redirect URL property in config.dart file to public 

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -6,10 +6,10 @@ A Flutter OAuth package example for performing user authentication against Azure
 
 Register an App in the [Azure App registration portal](https://apps.dev.microsoft.com/). Use native app as plattform type (with callback URL: https://login.live.com/oauth20_desktop.srf).
 
-Add your Azure tenant ID and client ID (ID of App) in the main.dart source-code:
+Add your Azure tenant ID, client ID (ID of App) and redirectUrl in the main.dart source-code:
 
 ```dart
-static final Config config = new Config("YOUR_TENANT_ID", "YOUR CLIENT ID", "openid profile offline_access");
+static final Config config = new Config("YOUR_TENANT_ID", "YOUR CLIENT ID", "openid profile offline_access", "your redirect url available in azure portal");
 ```
 
 Afterwards you can login and get an access token for accessing other resources.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,7 +36,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  static final Config config = new Config("YOUR_TENANT_ID", "YOUR CLIENT ID", "openid profile offline_access");
+  static final Config config = new Config("YOUR_TENANT_ID", "YOUR CLIENT ID", "openid profile offline_access", "https://login.live.com/oauth20_desktop.srf",);
   final AadOAuth oauth = AadOAuth(config);
 
   Widget build(BuildContext context) {

--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -12,9 +12,8 @@ class Config {
   final String scope;
   Size screenSize;
 
-  Config(this.azureTennantId, this.clientId, this.scope,
+  Config(this.azureTennantId, this.clientId, this.scope, this.redirectUri,
       {this.clientSecret,
-      this.redirectUri = "https://login.live.com/oauth20_desktop.srf",
       this.responseType = "code",
       this.contentType = "application/x-www-form-urlencoded",
       this.screenSize}) {


### PR DESCRIPTION
Expose Redirect URL property in config.dart file to public since if anyone wants to use different redirectURL then we need to make change inside oauth framework.

Actual:
this.redirectUri = "https://login.live.com/oauth20_desktop.srf"

Expected:
expose above RedirectUri property to public and i can pass my own URL.