### PR TITLE
Expose webview rect area to public for customization

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,9 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Widget build(BuildContext context) {
     // adjust window size for browser login
-    oauth.setWebViewScreenSize(MediaQuery.of(context).size);
+    var screenSize = MediaQuery.of(context).size;
+    var rectSize =  Rect.fromLTWH(0.0, 25.0, screenSize.width, screenSize.height - 25);
+    oauth.setWebViewScreenSize(rectSize);
 
     return new Scaffold(
       appBar: new AppBar(

--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -31,7 +31,7 @@ class AadOAuth {
     _requestToken = new RequestToken(_config);
   }
 
-  void setWebViewScreenSize(Size screenSize) {
+  void setWebViewScreenSize(Rect screenSize) {
     _config.screenSize = screenSize;
   }
 

--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -10,7 +10,7 @@ class Config {
   final String responseType;
   final String contentType;
   final String scope;
-  Size screenSize;
+  Rect screenSize;
 
   Config(this.azureTennantId, this.clientId, this.scope,
       {this.clientSecret,

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -27,7 +27,7 @@ class RequestCode {
         Uri.encodeFull("${_authorizationRequest.url}?$urlParams"),
         clearCookies: _authorizationRequest.clearCookies, 
         hidden: true,  
-        rect: screenSize
+        rect: _config.screenSize
     );
 
 

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -27,13 +27,7 @@ class RequestCode {
         Uri.encodeFull("${_authorizationRequest.url}?$urlParams"),
         clearCookies: _authorizationRequest.clearCookies, 
         hidden: true,  
-        rect: _config.screenSize != null ?
-          (_config.screenSize.height > 0 && _config.screenSize.width > 0) ? Rect.fromLTWH(
-          0.0,
-          25.0,
-          _config.screenSize.width,
-          _config.screenSize.height-25) : null
-        : null
+        rect: screenSize
     );
 
 


### PR DESCRIPTION
WebView UI is overlapping with status bar in Samsung galaxy s10+ mobile.
This issue on iOS works perfect, but on Android devices i am seeing grey bar on top.

Expected:
If i expose webview rect area to public, evryone can customize the webview rect area and fix the statusbar bug according to android or ios platforms. By using platform dependendent bool value we can get ios or android device the app is running and we can customize the webview issues according to the platforms(ios and android).