### PR TITLE
Allow webview size to be changed after creation and report failure to acquire token as null

### DIFF
--- a/example/android/app/local.properties
+++ b/example/android/app/local.properties
@@ -1,0 +1,8 @@
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Sun Jul 14 20:16:02 AEST 2019
+sdk.dir=c\:\\dev\\android

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Sun Jul 14 20:17:38 AEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -32,9 +32,12 @@ class AadOAuth {
   }
 
   void setWebViewScreenSize(Rect screenSize) {
-    _config.screenSize = screenSize;
+    if (screenSize != _config.screenSize) {
+      _config.screenSize = screenSize;
+      _requestCode.sizeChanged();
+    }
   }
-
+  
   Future<void> login() async {
     await _removeOldTokenOnFirstLogin();
     if (!Token.tokenIsValid(_token) )

--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -47,7 +47,7 @@ class AadOAuth {
   Future<String> getAccessToken() async {
     if (!Token.tokenIsValid(_token) )
       await _performAuthorization();
-
+    if (_token == null) return null;
     return _token.accessToken;
   }
 

--- a/lib/helper/auth_storage.dart
+++ b/lib/helper/auth_storage.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/services.dart';
 import 'package:aad_oauth/model/token.dart';
 import "dart:convert" as Convert;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -15,7 +16,16 @@ class AuthStorage {
   }
 
   Future<T> loadTokenToCache<T extends Token>() async {
-    var json = await _secureStorage.read(key:_identifier);
+    String json;
+    try {
+      json = await _secureStorage.read(key:_identifier);
+    } on PlatformException catch (_) {
+      // We may not be able to read the storage - if not
+      // just continue as if there was none
+      // This deals with Android secure storage decryption
+      // problems after a fresh uninstall/reinstall
+    }
+
     if (json == null) return null;
     try {
       var data = Convert.jsonDecode(json);

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -12,7 +12,7 @@ class RequestCode {
   AuthorizationRequest _authorizationRequest;
 
   var _onCodeStream;
-  
+
   RequestCode(Config config) : _config = config {
     _authorizationRequest = new AuthorizationRequest(config);
   }
@@ -20,26 +20,23 @@ class RequestCode {
   Future<String> requestCode() async {
     var code;
     final String urlParams = _constructUrlParams();
-    
+
     // workaround for webview overlapping statusbar
     // if we have a screen size use it to adjust the webview
     await _webView.launch(
         Uri.encodeFull("${_authorizationRequest.url}?$urlParams"),
-        clearCookies: _authorizationRequest.clearCookies, 
-        hidden: true,  
-        rect: _config.screenSize
-    );
-
+        clearCookies: _authorizationRequest.clearCookies,
+        hidden: true,
+        rect: _config.screenSize);
 
     _webView.onStateChanged.listen((WebViewStateChanged change) {
-        if ( change.type.index == 2)
-          _webView.show();
+      if (change.type.index == 2) _webView.show();
     });
 
     _webView.onUrlChanged.listen((String url) {
       Uri uri = Uri.parse(url);
       Uri configUri = Uri.parse(_authorizationRequest.redirectUrl);
-      if ( uri.host == configUri.host )
+      if (uri.host == configUri.host)
         _onCodeListener.add(uri.queryParameters["code"]);
     });
 
@@ -47,6 +44,10 @@ class RequestCode {
     await _webView.close();
 
     return code;
+  }
+
+  void sizeChanged() {
+    _webView.resize(_config.screenSize);
   }
 
   Future<void> clearCookies() async {
@@ -57,7 +58,8 @@ class RequestCode {
   Stream<String> get _onCode =>
       _onCodeStream ??= _onCodeListener.stream.asBroadcastStream();
 
-  String _constructUrlParams() => _mapToQueryParams(_authorizationRequest.parameters);
+  String _constructUrlParams() =>
+      _mapToQueryParams(_authorizationRequest.parameters);
 
   String _mapToQueryParams(Map<String, String> params) {
     final queryParams = <String>[];
@@ -65,5 +67,4 @@ class RequestCode {
         .forEach((String key, String value) => queryParams.add("$key=$value"));
     return queryParams.join("&");
   }
-
 }

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -36,6 +36,13 @@ class RequestCode {
     _webView.onUrlChanged.listen((String url) {
       Uri uri = Uri.parse(url);
       Uri configUri = Uri.parse(_authorizationRequest.redirectUrl);
+      if (uri.queryParameters.containsKey("error")) {
+        // An error occurred (e.g. user didn't authenticate, or pressed Back
+        // or some othe problem) - leave it to the caller to work out what to
+        // do. Publish a null token
+        _onCodeListener.add(null);
+        return;
+      }
       if (uri.host == configUri.host)
         _onCodeListener.add(uri.queryParameters["code"]);
     });

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -1,6 +1,4 @@
 import 'dart:async';
-import 'dart:ui';
-import 'package:flutter/widgets.dart';
 import 'request/authorization_request.dart';
 import 'model/config.dart';
 import 'package:flutter_webview_plugin/flutter_webview_plugin.dart';

--- a/lib/request_token.dart
+++ b/lib/request_token.dart
@@ -14,6 +14,7 @@ class RequestToken {
   RequestToken(this.config);
 
   Future<Token> requestToken(String code) async {
+    if (code == null) return Future.value(null);
     _generateTokenRequest(code);
     return await _sendTokenRequest(_tokenRequest.url, _tokenRequest.params, _tokenRequest.headers);
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -34,6 +34,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.1+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -66,7 +73,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+1"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
@@ -81,13 +88,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.2"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.3+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -113,7 +134,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -127,14 +148,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.4"
   typed_data:
     dependency: transitive
     description:
@@ -150,4 +171,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.0.0 <3.0.0"
+  dart: ">=2.2.0 <3.0.0"
+  flutter: ">=1.5.0 <2.0.0"

--- a/test/aad_oauth_test.dart
+++ b/test/aad_oauth_test.dart
@@ -4,14 +4,15 @@ import 'package:aad_oauth/aad_oauth.dart';
 import 'package:aad_oauth/model/config.dart';
 
 void main() {
-  test('adds one to input values', () {
+  test('Token is not valid before signing in', () {
     final Config config = new Config(
-      "YOUR TENANT ID",
-      "YOUR CLIENT ID",
-      "openid profile offline_access");
+        "YOUR TENANT ID",
+        "YOUR CLIENT ID",
+        "openid profile offline_access",
+        "https://login.live.com/oauth20_desktop.srf");
     final AadOAuth oauth = new AadOAuth(config);
 
+    expect(oauth.tokenIsValid(), false);
     //TODO testing
-    
   });
 }


### PR DESCRIPTION
These commits allow 

- the flutter app to resize the webview when the screen dimensions change (e.g. user rotates their device from portrait to landscape).
- Reporting failure to authenticate (which can happen if the user hits Back on the webview) as a null token, which the caller can then deal with (e.g. by changing state, or retrying etc)
- Updates the config sample in the unit test to remove a mandatory parameter warning.
- Deals with android secure storage decryption exception when an app is uninstalled, then reinstalls by assuming the token did not exist and allowing the normal auth flow to continue