### PR TITLE
Added id_token support

### DIFF
--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -48,6 +48,13 @@ class AadOAuth {
     return _token.accessToken;
   }
 
+  Future<String> getIdToken() async {
+    if (!Token.tokenIsValid(_token) )
+      await _performAuthorization();
+
+    return _token.idToken;
+  }
+
   bool tokenIsValid() {
     return Token.tokenIsValid(_token);
   }

--- a/lib/model/token.dart
+++ b/lib/model/token.dart
@@ -37,6 +37,9 @@ class Token {
       if (model.expireTimeStamp != null) {
         ret["expire_timestamp"] = model.expireTimeStamp.millisecondsSinceEpoch;
       }
+      if (model.idToken != null) {
+        ret["id_token"] = model.idToken;
+      }
     }
     return ret;
   }

--- a/lib/model/token.dart
+++ b/lib/model/token.dart
@@ -5,6 +5,7 @@ class Token {
   String accessToken;
   String tokenType;
   String refreshToken;
+  String idToken;
   DateTime issueTimeStamp;
   DateTime expireTimeStamp;
   int expiresIn;
@@ -56,6 +57,7 @@ class Token {
         ? map["expires_in"]
         : int.tryParse(map["expires_in"].toString()) ?? 60;
     model.refreshToken = map["refresh_token"];
+    model.idToken = map.containsKey("id_token") ? map["id_token"] : '';
     model.issueTimeStamp = new DateTime.now().toUtc();
     model.expireTimeStamp = map.containsKey("expire_timestamp")
         ? DateTime.fromMillisecondsSinceEpoch(map["expire_timestamp"])


### PR DESCRIPTION
Support id_token retrieval when it is optionally requested and contained within the response. 
Required to be able to obtain information about issuer, name, etc.

Requested in #31 