### PR TITLE
Config tokenIdentifier default value

### DIFF
--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -124,7 +124,7 @@ class Config {
       this.codeChallenge,
       this.codeChallengeMethod,
       this.nonce = '12345',
-      this.tokenIdentifier,
+      this.tokenIdentifier = 'Token',
       this.clientSecret,
       this.resource,
       this.isB2C = false,


### PR DESCRIPTION
The refresh token doesn't get saved on iOS when the key is null (for some reason it works for Android, perhaps a null key works in SharedPreferences).
The `AuthStorage` constructor does specify a default value for `tokenIdentifier`, but because of [this](https://github.com/Earlybyte/aad_oauth/blob/cab4529dc3454dbd01868655eac96b979c4fb5dc/lib/aad_oauth.dart#L24) the default doesn't apply.

This would probably solve #57 as well.