### PR TITLE
Expose expireTimeStamp

### DIFF
--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -47,6 +47,10 @@ class AadOAuth {
   Future<String> getIdToken() async =>
       (await _authStorage.loadTokenFromCache()).idToken;
 
+  /// Retrieve cached OAuth token predicted expiration time.
+  Future<DateTime> getExpireTimeStamp() async =>
+      (await _authStorage.loadTokenFromCache()).expireTimeStamp;
+
   /// Perform Azure AD logout.
   Future<void> logout() async {
     await _authStorage.clear();


### PR DESCRIPTION
Access to expireTimeStamp is necessary when scheduling token refresh (not using AadOAuth directly every time).

One should never rely on decoding the `access_token`, per Microsoft's guidelines.
A client must always treat it as an opaque token, as it may be encrypted or not JWT at all ([documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens)).