### PR TITLE
Add refreshIfAvailable flag to login()

### DIFF
--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -34,9 +34,15 @@ class AadOAuth {
   }
 
   /// Perform Azure AD login.
-  Future<void> login() async {
+  ///
+  /// Setting [refreshIfAvailable] to [true] will attempt to re-authenticate
+  /// with the existing refresh token, if any, even though the access token may
+  /// still be valid. If there's no refresh token the existing access token
+  /// will be returned, as long as we deem it still valid. In the event that
+  /// both access and refresh tokens are invalid, the web gui will be used.
+  Future<void> login([bool refreshIfAvailable = false]) async {
     await _removeOldTokenOnFirstLogin();
-    await _authorization();
+    await _authorization(refreshIfAvailable);
   }
 
   /// Retrieve cached OAuth Access Token.
@@ -54,11 +60,19 @@ class AadOAuth {
   }
 
   /// Authorize user via refresh token or web gui if necessary.
-  Future<Token> _authorization() async {
+  ///
+  /// Setting [refreshIfAvailable] to [true] will attempt to re-authenticate
+  /// with the existing refresh token, if any, even though the access token may
+  /// still be valid. If there's no refresh token the existing access token
+  /// will be returned, as long as we deem it still valid. In the event that
+  /// both access and refresh tokens are invalid, the web gui will be used.
+  Future<Token> _authorization([bool refreshIfAvailable = false]) async {
     var token = await _authStorage.loadTokenFromCache();
 
-    if (token.hasValidAccessToken()) {
-      return token;
+    if (!refreshIfAvailable) {
+      if (token.hasValidAccessToken()) {
+        return token;
+      }
     }
 
     if (token.hasRefreshToken()) {

--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -40,9 +40,9 @@ class AadOAuth {
   /// still be valid. If there's no refresh token the existing access token
   /// will be returned, as long as we deem it still valid. In the event that
   /// both access and refresh tokens are invalid, the web gui will be used.
-  Future<void> login([bool refreshIfAvailable = false]) async {
+  Future<void> login({bool refreshIfAvailable = false}) async {
     await _removeOldTokenOnFirstLogin();
-    await _authorization(refreshIfAvailable);
+    await _authorization(refreshIfAvailable: refreshIfAvailable);
   }
 
   /// Retrieve cached OAuth Access Token.
@@ -66,7 +66,7 @@ class AadOAuth {
   /// still be valid. If there's no refresh token the existing access token
   /// will be returned, as long as we deem it still valid. In the event that
   /// both access and refresh tokens are invalid, the web gui will be used.
-  Future<Token> _authorization([bool refreshIfAvailable = false]) async {
+  Future<Token> _authorization({bool refreshIfAvailable = false}) async {
     var token = await _authStorage.loadTokenFromCache();
 
     if (!refreshIfAvailable) {


### PR DESCRIPTION
There's a chance that the consuming API, client and Azure AD might be out of sync with regards to time.
This creates a temporal dependency when you only depend on the client's current time.

For this reason, robust clients should instead listen for 401 HTTP response codes to then attempt to refresh the access tokens.
This PR enables you to force the use of the refresh token if it is available.

If a refresh token is not available (i.e. due to missing scope), it'll fall back to check the expiry using the client's local time. If that's still valid it'll return the existing access token.

If any of these fail, it'll still show the full web gui flow as a last resort.