### PR TITLE
Null safety only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.0] - 20200725
+
+- Migrate package and examples to sound null safety [#105](https://github.com/Earlybyte/aad_oauth/pull/105)
+
 ## [0.2.2] - 20200702
 
 - Add refreshIfAvailable flag to login() [#94](https://github.com/Earlybyte/aad_oauth/pull/94)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the following to your pubspec.yaml dependencies:
 
 ```yaml
 dependencies:
-  aad_oauth: "^0.2.0"
+  aad_oauth: "^0.3.0"
 ```
 
 ## Contribution

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -37,10 +37,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     // adjust window size for browser login
-    var screenSize = MediaQuery.of(context).size;
-    var rectSize =
-        Rect.fromLTWH(0.0, 25.0, screenSize.width, screenSize.height - 25);
-    oauth.setWebViewScreenSize(rectSize);
+    oauth.setWebViewScreenSizeFromMedia(MediaQuery.of(context));
 
     return Scaffold(
       appBar: AppBar(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   aad_oauth:

--- a/example_b2c/lib/main.dart
+++ b/example_b2c/lib/main.dart
@@ -28,7 +28,7 @@ class _MyAppState extends State<MyApp> {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -64,10 +64,10 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     // adjust window size for browser login
-    var screenSize = MediaQuery.of(context).size;
-    var rectSize =
-        Rect.fromLTWH(0.0, 25.0, screenSize.width, screenSize.height - 25);
-    oauthB2Ca.setWebViewScreenSize(rectSize);
+
+    var media = MediaQuery.of(context);
+    oauthB2Ca.setWebViewScreenSizeFromMedia(media);
+    oauthB2Cb.setWebViewScreenSizeFromMedia(media);
 
     return Scaffold(
       appBar: AppBar(

--- a/example_b2c/pubspec.lock
+++ b/example_b2c/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   async:
     dependency: transitive
     description:
@@ -183,7 +183,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   process:
     dependency: transitive
     description:
@@ -300,7 +300,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.4"
+    version: "2.2.5"
   xdg_directories:
     dependency: transitive
     description:

--- a/example_b2c/pubspec.yaml
+++ b/example_b2c/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   aad_oauth:

--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -11,19 +11,18 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 /// Authenticates a user with Azure Active Directory using OAuth2.0.
 class AadOAuth {
-  static Config _config;
-  AuthStorage _authStorage;
-  RequestCode _requestCode;
-  RequestToken _requestToken;
+  final Config _config;
+  final AuthStorage _authStorage;
+  final RequestCode _requestCode;
+  final RequestToken _requestToken;
 
   /// Instantiating AadOAuth authentication.
   /// [config] Parameters according to official Microsoft Documentation.
-  AadOAuth(Config config) {
-    _config = config;
-    _authStorage = AuthStorage(tokenIdentifier: config.tokenIdentifier);
-    _requestCode = RequestCode(_config);
-    _requestToken = RequestToken(_config);
-  }
+  AadOAuth(Config config)
+      : _config = config,
+        _authStorage = AuthStorage(tokenIdentifier: config.tokenIdentifier),
+        _requestCode = RequestCode(config),
+        _requestToken = RequestToken(config);
 
   /// Set [screenSize] of webview.
   void setWebViewScreenSize(Rect screenSize) {

--- a/lib/aad_oauth.dart
+++ b/lib/aad_oauth.dart
@@ -32,6 +32,16 @@ class AadOAuth {
     }
   }
 
+  void setWebViewScreenSizeFromMedia(MediaQueryData media) {
+    final rect = Rect.fromLTWH(
+      media.padding.left,
+      media.padding.top,
+      media.size.width - media.padding.left - media.padding.right,
+      media.size.height - media.padding.top - media.padding.bottom,
+    );
+    setWebViewScreenSize(rect);
+  }
+
   /// Perform Azure AD login.
   ///
   /// Setting [refreshIfAvailable] to [true] will attempt to re-authenticate
@@ -45,11 +55,11 @@ class AadOAuth {
   }
 
   /// Retrieve cached OAuth Access Token.
-  Future<String> getAccessToken() async =>
+  Future<String?> getAccessToken() async =>
       (await _authStorage.loadTokenFromCache()).accessToken;
 
   /// Retrieve cached OAuth Id Token.
-  Future<String> getIdToken() async =>
+  Future<String?> getIdToken() async =>
       (await _authStorage.loadTokenFromCache()).idToken;
 
   /// Perform Azure AD logout.
@@ -75,7 +85,7 @@ class AadOAuth {
     }
 
     if (token.hasRefreshToken()) {
-      token = await _requestToken.requestRefreshToken(token.refreshToken);
+      token = await _requestToken.requestRefreshToken(token.refreshToken!);
     }
 
     if (!token.hasValidAccessToken()) {

--- a/lib/helper/auth_storage.dart
+++ b/lib/helper/auth_storage.dart
@@ -20,13 +20,13 @@ class AuthStorage {
 
   Future<T> loadTokenFromCache<T extends Token>() async {
     var json = await _secureStorage.read(key: _tokenIdentifier);
-    if (json == null) return emptyToken;
+    if (json == null) return emptyToken as FutureOr<T>;
     try {
       var data = jsonDecode(json);
-      return _getTokenFromMap<T>(data);
+      return _getTokenFromMap<T>(data) as FutureOr<T>;
     } catch (exception) {
       print(exception);
-      return emptyToken;
+      return emptyToken as FutureOr<T>;
     }
   }
 

--- a/lib/helper/auth_storage.dart
+++ b/lib/helper/auth_storage.dart
@@ -6,11 +6,11 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 class AuthStorage {
   static AuthStorage shared = AuthStorage();
   final FlutterSecureStorage _secureStorage = FlutterSecureStorage();
-  String _tokenIdentifier;
+  final String _tokenIdentifier;
+  final Token emptyToken = Token();
 
-  AuthStorage({String tokenIdentifier = 'Token'}) {
-    _tokenIdentifier = tokenIdentifier;
-  }
+  AuthStorage({String tokenIdentifier = 'Token'})
+      : _tokenIdentifier = tokenIdentifier;
 
   Future<void> saveTokenToCache(Token token) async {
     var data = Token.toJsonMap(token);
@@ -19,7 +19,6 @@ class AuthStorage {
   }
 
   Future<T> loadTokenFromCache<T extends Token>() async {
-    var emptyToken = Token();
     var json = await _secureStorage.read(key: _tokenIdentifier);
     if (json == null) return emptyToken;
     try {

--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -7,10 +7,10 @@ import 'package:flutter/widgets.dart';
 /// DartDocs of parameters are mostly from those pages.
 class Config {
   /// Azure AD authorization URL.
-  String/*!*/ authorizationUrl;
+  final String authorizationUrl;
 
   /// Azure AD token URL.
-  String/*!*/ tokenUrl;
+  final String tokenUrl;
 
   /// The tenant value in the path of the request can be used to control who can sign into the application.
   /// The allowed values are common, organizations, consumers, and tenant identifiers. Or Name of your Azure AD B2C tenant.
@@ -18,7 +18,7 @@ class Config {
 
   /// __AAD B2C only__: The user flow to be run. Specify the name of a user flow you've created in your Azure AD B2C tenant.
   /// For example: b2c_1_sign_in, b2c_1_sign_up, or b2c_1_edit_profile
-  final String policy;
+  final String? policy;
 
   /// The Application (client) ID that the Azure portal – App registrations experience assigned to your app.
   final String clientId;
@@ -40,23 +40,23 @@ class Config {
   /// - query
   /// - fragment
   /// - form_post
-  final String responseMode;
+  final String? responseMode;
 
   /// A value included in the request that will also be returned in the token response.
   /// It can be a string of any content that you wish.
   /// A randomly generated unique value is typically used for preventing cross-site request forgery attacks.
   /// The value can also encode information about the user's state in the app before the authentication request occurred, such as the page or view they were on.
-  final String state;
+  final String? state;
 
   /// Indicates the type of user interaction that is required.
   /// The only valid values at this time are *login*, *none*, and *consent*.
-  final String prompt;
+  final String? prompt;
 
   /// Used to secure authorization code grants via Proof Key for Code Exchange (PKCE).
   /// Required if [codeChallengeMethod] is included.
   /// For more information, see the PKCE RFC.
   /// This is now recommended for all application types - native apps, SPAs, and confidential clients like web apps.
-  final String codeChallenge;
+  final String? codeChallenge;
 
   /// The method used to encode the code_verifier for the code_challenge parameter.
   /// This SHOULD be S256, but the spec allows the use of plain if for some reason the client cannot support SHA256.
@@ -64,17 +64,17 @@ class Config {
   /// Microsoft identity platform supports both plain and S256.
   /// For more information, see the PKCE RFC.
   /// This is required for single page apps using the authorization code flow.
-  final String codeChallengeMethod;
+  final String? codeChallengeMethod;
 
   ///	Can be used to pre-fill the username/email address field of the sign-in page for the user, if you know their username ahead of time.
   /// Often apps will use this parameter during re-authentication, having already extracted the username from a previous sign-in using the preferred_username claim.
-  String loginHint;
+  String? loginHint;
 
   /// If included, it will skip the email-based discovery process that user goes through on the sign-in page, leading to a slightly more streamlined user experience - for example, sending them to their federated identity provider.
   /// Often apps will use this parameter during re-authentication, by extracting the tid from a previous sign-in.
   /// If the tid claim value is 9188040d-6c67-4c5b-b112-36a304b66dad, you should use domain_hint=consumers.
   /// Otherwise, use domain_hint=organizations.
-  String domainHint;
+  String? domainHint;
 
   /// __AAD B2C only__: A nonce is a strategy used to mitigate token replay attacks.
   /// Your application can specify a nonce in an authorization request by using the nonce query parameter.
@@ -87,37 +87,37 @@ class Config {
   String tokenIdentifier;
 
   /// The client secret that you generated for your app in the app registration portal.
-  final String clientSecret;
+  final String? clientSecret;
 
   /// The same code_verifier that was used to obtain the authorization_code.
   /// Required if PKCE was used in the authorization code grant request.
   /// For more information, see the PKCE RFC.
-  String codeVerifier;
+  String? codeVerifier;
 
   /// Content type for token request.
   static const String contentType = 'application/x-www-form-urlencoded';
 
   /// Resource
-  final String resource;
+  final String? resource;
 
   /// Using Azure AD B2C instead of standard Azure AD.
   /// Azure Active Directory B2C provides business-to-customer identity as a service.
   final bool isB2C;
 
   /// Current screen size.
-  Rect screenSize;
+  Rect? screenSize;
 
   /// User agent of web view. (using flutter_webview_plugin)
-  String userAgent;
+  String? userAgent;
 
   /// Azure AD OAuth Configuration. Look at individual fields for description.
   Config(
-      {@required this.tenant,
+      {required this.tenant,
       this.policy,
-      @required this.clientId,
+      required this.clientId,
       this.responseType = 'code',
-      @required this.redirectUri,
-      @required this.scope,
+      required this.redirectUri,
+      required this.scope,
       this.responseMode,
       this.state,
       this.prompt,
@@ -131,12 +131,11 @@ class Config {
       this.loginHint,
       this.domainHint,
       this.codeVerifier,
-      this.userAgent}) {
-    authorizationUrl = isB2C
-        ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/authorize'
-        : 'https://login.microsoftonline.com/$tenant/oauth2/v2.0/authorize';
-    tokenUrl = isB2C
-        ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/token'
-        : 'https://login.microsoftonline.com/$tenant/oauth2/v2.0/token';
-  }
+      this.userAgent})
+      : authorizationUrl = isB2C
+            ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/authorize'
+            : 'https://login.microsoftonline.com/$tenant/oauth2/v2.0/authorize',
+        tokenUrl = isB2C
+            ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/token'
+            : 'https://login.microsoftonline.com/$tenant/oauth2/v2.0/token';
 }

--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -7,10 +7,10 @@ import 'package:flutter/widgets.dart';
 /// DartDocs of parameters are mostly from those pages.
 class Config {
   /// Azure AD authorization URL.
-  String authorizationUrl;
+  String/*!*/ authorizationUrl;
 
   /// Azure AD token URL.
-  String tokenUrl;
+  String/*!*/ tokenUrl;
 
   /// The tenant value in the path of the request can be used to control who can sign into the application.
   /// The allowed values are common, organizations, consumers, and tenant identifiers. Or Name of your Azure AD B2C tenant.

--- a/lib/model/token.dart
+++ b/lib/model/token.dart
@@ -11,7 +11,7 @@ class Token {
 
   /// An OAuth 2.0 refresh token. The app can use this token acquire additional access tokens after the current access token expires. Refresh_tokens are long-lived, and can be used to retain access to resources for extended periods of time. For more detail on refreshing an access token, refer to the section below.
   /// Note: Only provided if offline_access [scope] was requested.
-  String refreshToken;
+  String/*!*/ refreshToken;
 
   /// A JSON Web Token (JWT). The app can decode the segments of this token to request information about the user who signed in.
   /// The app can cache the values and display them, and confidential clients can use this for authorization.
@@ -32,7 +32,7 @@ class Token {
   Token();
 
   /// JSON map to Token factory.
-  factory Token.fromJson(Map<String, dynamic> json) => Token.fromMap(json);
+  factory Token.fromJson(Map<String, dynamic>/*!*/ json) => Token.fromMap(json);
 
   /// Convert this Token to JSON map.
   Map toMap() => Token.toJsonMap(this);

--- a/lib/model/token.dart
+++ b/lib/model/token.dart
@@ -4,35 +4,35 @@ class Token {
   final expireOffSet = 5;
 
   /// The requested access token. The app can use this token to authenticate to the secured resource, such as a web API.
-  String accessToken;
+  String? accessToken;
 
   /// Indicates the token type value. The only type that Azure AD supports is Bearer.
-  String tokenType;
+  String? tokenType;
 
   /// An OAuth 2.0 refresh token. The app can use this token acquire additional access tokens after the current access token expires. Refresh_tokens are long-lived, and can be used to retain access to resources for extended periods of time. For more detail on refreshing an access token, refer to the section below.
   /// Note: Only provided if offline_access [scope] was requested.
-  String/*!*/ refreshToken;
+  String? refreshToken;
 
   /// A JSON Web Token (JWT). The app can decode the segments of this token to request information about the user who signed in.
   /// The app can cache the values and display them, and confidential clients can use this for authorization.
   /// For more information about id_tokens, see the id_token reference.
   /// Note: Only provided if openid [scope] was requested.
-  String idToken;
+  String? idToken;
 
   /// Current time when token was issued.
-  DateTime issueTimeStamp;
+  late DateTime issueTimeStamp;
 
   /// Predicted token expiration time.
-  DateTime expireTimeStamp;
+  DateTime? expireTimeStamp;
 
   /// How long the access token is valid (in seconds).
-  int expiresIn;
+  int? expiresIn;
 
   /// Access token enabling to securely call protected APIs on behalf of the user.
   Token();
 
   /// JSON map to Token factory.
-  factory Token.fromJson(Map<String, dynamic>/*!*/ json) => Token.fromMap(json);
+  factory Token.fromJson(Map<String, dynamic>? json) => Token.fromMap(json);
 
   /// Convert this Token to JSON map.
   Map toMap() => Token.toJsonMap(this);
@@ -43,31 +43,29 @@ class Token {
   /// Convert Token to JSON map.
   static Map toJsonMap(Token model) {
     var ret = {};
-    if (model != null) {
-      if (model.accessToken != null) {
-        ret['access_token'] = model.accessToken;
-      }
-      if (model.tokenType != null) {
-        ret['token_type'] = model.tokenType;
-      }
-      if (model.refreshToken != null) {
-        ret['refresh_token'] = model.refreshToken;
-      }
-      if (model.expiresIn != null) {
-        ret['expires_in'] = model.expiresIn;
-      }
-      if (model.expireTimeStamp != null) {
-        ret['expire_timestamp'] = model.expireTimeStamp.millisecondsSinceEpoch;
-      }
-      if (model.idToken != null) {
-        ret['id_token'] = model.idToken;
-      }
+    if (model.accessToken != null) {
+      ret['access_token'] = model.accessToken;
+    }
+    if (model.tokenType != null) {
+      ret['token_type'] = model.tokenType;
+    }
+    if (model.refreshToken != null) {
+      ret['refresh_token'] = model.refreshToken;
+    }
+    if (model.expiresIn != null) {
+      ret['expires_in'] = model.expiresIn;
+    }
+    if (model.expireTimeStamp != null) {
+      ret['expire_timestamp'] = model.expireTimeStamp!.millisecondsSinceEpoch;
+    }
+    if (model.idToken != null) {
+      ret['id_token'] = model.idToken;
     }
     return ret;
   }
 
   /// Convert JSON map to Token.
-  static Token fromMap(Map map) {
+  static Token fromMap(Map<String, dynamic>? map) {
     if (map == null) throw Exception('No token from received');
     //error handling as described in https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#error-response-1
     if (map['error'] != null) {
@@ -89,7 +87,7 @@ class Token {
     model.expireTimeStamp = map.containsKey('expire_timestamp')
         ? DateTime.fromMillisecondsSinceEpoch(map['expire_timestamp'])
         : model.issueTimeStamp
-            .add(Duration(seconds: model.expiresIn - model.expireOffSet));
+            .add(Duration(seconds: model.expiresIn! - model.expireOffSet));
 
     return model;
   }
@@ -97,7 +95,8 @@ class Token {
   /// Check if Access Token is set and not expired.
   bool hasValidAccessToken() {
     return accessToken != null &&
-        expireTimeStamp.isAfter(DateTime.now().toUtc());
+        expireTimeStamp != null &&
+        expireTimeStamp!.isAfter(DateTime.now().toUtc());
   }
 
   /// Check if Refresh Token is set.

--- a/lib/request/authorization_request.dart
+++ b/lib/request/authorization_request.dart
@@ -1,9 +1,9 @@
 import 'package:aad_oauth/model/config.dart';
 
 class AuthorizationRequest {
-  final String /*!*/ url;
-  final String /*!*/ redirectUrl;
-  final Map<String, String/*!*/> parameters;
+  final String url;
+  final String redirectUrl;
+  final Map<String, String> parameters;
   final bool fullScreen;
   final bool clearCookies;
 
@@ -16,37 +16,39 @@ class AuthorizationRequest {
           'response_type': config.responseType,
           'redirect_uri': config.redirectUri,
           'scope': config.scope,
-          'state': config.state,
         },
         fullScreen = fullScreen,
         clearCookies = clearCookies {
+    if (config.state != null) {
+      parameters.putIfAbsent('state', () => config.state!);
+    }
     if (config.responseMode != null) {
-      parameters.putIfAbsent('response_mode', () => config.responseMode);
+      parameters.putIfAbsent('response_mode', () => config.responseMode!);
     }
 
     if (config.prompt != null) {
-      parameters.putIfAbsent('prompt', () => config.prompt);
+      parameters.putIfAbsent('prompt', () => config.prompt!);
     }
 
     if (config.loginHint != null) {
-      parameters.putIfAbsent('login_hint', () => config.loginHint);
+      parameters.putIfAbsent('login_hint', () => config.loginHint!);
     }
 
     if (config.domainHint != null) {
-      parameters.putIfAbsent('domain_hint', () => config.domainHint);
+      parameters.putIfAbsent('domain_hint', () => config.domainHint!);
     }
 
     if (config.codeVerifier != null) {
-      parameters.putIfAbsent('code_verifier', () => config.codeVerifier);
+      parameters.putIfAbsent('code_verifier', () => config.codeVerifier!);
     }
 
     if (config.codeChallenge != null) {
-      parameters.putIfAbsent('code_challenge', () => config.codeChallenge);
+      parameters.putIfAbsent('code_challenge', () => config.codeChallenge!);
     }
 
     if (config.codeChallengeMethod != null) {
       parameters.putIfAbsent(
-          'code_challenge_method', () => config.codeChallengeMethod);
+          'code_challenge_method', () => config.codeChallengeMethod!);
     }
 
     if (config.isB2C) {

--- a/lib/request/authorization_request.dart
+++ b/lib/request/authorization_request.dart
@@ -1,25 +1,25 @@
 import 'package:aad_oauth/model/config.dart';
 
 class AuthorizationRequest {
-  String url;
-  String redirectUrl;
-  Map<String, String> parameters;
-  Map<String, String> headers;
-  bool fullScreen;
-  bool clearCookies;
+  final String /*!*/ url;
+  final String /*!*/ redirectUrl;
+  final Map<String, String/*!*/> parameters;
+  final bool fullScreen;
+  final bool clearCookies;
 
   AuthorizationRequest(Config config,
-      {bool fullScreen = true, bool clearCookies = false}) {
-    url = config.authorizationUrl;
-    redirectUrl = config.redirectUri;
-    parameters = {
-      'client_id': config.clientId,
-      'response_type': config.responseType,
-      'redirect_uri': config.redirectUri,
-      'scope': config.scope,
-      'state': config.state,
-    };
-
+      {bool fullScreen = true, bool clearCookies = false})
+      : url = config.authorizationUrl,
+        redirectUrl = config.redirectUri,
+        parameters = {
+          'client_id': config.clientId,
+          'response_type': config.responseType,
+          'redirect_uri': config.redirectUri,
+          'scope': config.scope,
+          'state': config.state,
+        },
+        fullScreen = fullScreen,
+        clearCookies = clearCookies {
     if (config.responseMode != null) {
       parameters.putIfAbsent('response_mode', () => config.responseMode);
     }
@@ -54,8 +54,5 @@ class AuthorizationRequest {
         'nonce': config.nonce,
       });
     }
-
-    this.fullScreen = fullScreen;
-    this.clearCookies = clearCookies;
   }
 }

--- a/lib/request/token_refresh_request.dart
+++ b/lib/request/token_refresh_request.dart
@@ -1,26 +1,25 @@
 import 'package:aad_oauth/model/config.dart';
 
 class TokenRefreshRequestDetails {
-  String url;
-  Map<String, String> params;
-  Map<String, String> headers;
+  final String url;
+  final Map<String, String /*!*/ > /*!*/ params;
+  final Map<String, String> /*!*/ headers;
 
-  TokenRefreshRequestDetails(Config config, String refreshToken) {
-    url = config.tokenUrl;
-    params = {
-      'client_id': config.clientId,
-      'scope': config.scope,
-      'redirect_uri': config.redirectUri,
-      'grant_type': 'refresh_token',
-      'refresh_token': refreshToken
-    };
+  TokenRefreshRequestDetails(Config config, String /*!*/ refreshToken)
+      : url = config.tokenUrl,
+        params = {
+          'client_id': config.clientId,
+          'scope': config.scope,
+          'redirect_uri': config.redirectUri,
+          'grant_type': 'refresh_token',
+          'refresh_token': refreshToken
+        },
+        headers = {
+          'Accept': 'application/json',
+          'Content-Type': Config.contentType
+        } {
     if (config.clientSecret != null) {
       params.putIfAbsent('client_secret', () => config.clientSecret);
     }
-
-    headers = {
-      'Accept': 'application/json',
-      'Content-Type': Config.contentType
-    };
   }
 }

--- a/lib/request/token_refresh_request.dart
+++ b/lib/request/token_refresh_request.dart
@@ -2,10 +2,10 @@ import 'package:aad_oauth/model/config.dart';
 
 class TokenRefreshRequestDetails {
   final String url;
-  final Map<String, String /*!*/ > /*!*/ params;
-  final Map<String, String> /*!*/ headers;
+  final Map<String, String > params;
+  final Map<String, String> headers;
 
-  TokenRefreshRequestDetails(Config config, String /*!*/ refreshToken)
+  TokenRefreshRequestDetails(Config config, String refreshToken)
       : url = config.tokenUrl,
         params = {
           'client_id': config.clientId,
@@ -19,7 +19,7 @@ class TokenRefreshRequestDetails {
           'Content-Type': Config.contentType
         } {
     if (config.clientSecret != null) {
-      params.putIfAbsent('client_secret', () => config.clientSecret);
+      params.putIfAbsent('client_secret', () => config.clientSecret!);
     }
   }
 }

--- a/lib/request/token_request.dart
+++ b/lib/request/token_request.dart
@@ -1,20 +1,23 @@
 import 'package:aad_oauth/model/config.dart';
 
 class TokenRequestDetails {
-  String url;
-  Map<String, String> params;
-  Map<String, String> headers;
+  final String url;
+  final Map<String, String/*!*/> params;
+  final Map<String, String> headers;
 
-  TokenRequestDetails(Config config, String code) {
-    url = config.tokenUrl;
-    params = {
-      'client_id': config.clientId,
-      'grant_type': 'authorization_code',
-      'scope': config.scope,
-      'code': code,
-      'redirect_uri': config.redirectUri,
-    };
-
+  TokenRequestDetails(Config config, String code)
+      : url = config.tokenUrl,
+        params = {
+          'client_id': config.clientId,
+          'grant_type': 'authorization_code',
+          'scope': config.scope,
+          'code': code,
+          'redirect_uri': config.redirectUri,
+        },
+        headers = {
+          'Accept': 'application/json',
+          'Content-Type': Config.contentType
+        } {
     if (config.resource != null) {
       params.putIfAbsent('resource', () => config.resource);
     }
@@ -26,10 +29,5 @@ class TokenRequestDetails {
     if (config.codeVerifier != null) {
       params.putIfAbsent('code_verifier', () => config.codeVerifier);
     }
-
-    headers = {
-      'Accept': 'application/json',
-      'Content-Type': Config.contentType
-    };
   }
 }

--- a/lib/request/token_request.dart
+++ b/lib/request/token_request.dart
@@ -2,7 +2,7 @@ import 'package:aad_oauth/model/config.dart';
 
 class TokenRequestDetails {
   final String url;
-  final Map<String, String/*!*/> params;
+  final Map<String, String> params;
   final Map<String, String> headers;
 
   TokenRequestDetails(Config config, String code)
@@ -19,15 +19,15 @@ class TokenRequestDetails {
           'Content-Type': Config.contentType
         } {
     if (config.resource != null) {
-      params.putIfAbsent('resource', () => config.resource);
+      params.putIfAbsent('resource', () => config.resource!);
     }
 
     if (config.clientSecret != null) {
-      params.putIfAbsent('client_secret', () => config.clientSecret);
+      params.putIfAbsent('client_secret', () => config.clientSecret!);
     }
 
     if (config.codeVerifier != null) {
-      params.putIfAbsent('code_verifier', () => config.codeVerifier);
+      params.putIfAbsent('code_verifier', () => config.codeVerifier!);
     }
   }
 }

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -4,24 +4,24 @@ import 'model/config.dart';
 import 'package:flutter_webview_plugin/flutter_webview_plugin.dart';
 
 class RequestCode {
-  final StreamController<String> _onCodeListener = StreamController();
+  final StreamController<String?> _onCodeListener = StreamController();
   final FlutterWebviewPlugin _webView = FlutterWebviewPlugin();
   final Config _config;
   final AuthorizationRequest _authorizationRequest;
 
-  /*late */ Stream<String> _onCodeStream;
+  late Stream<String?> _onCodeStream;
 
   RequestCode(Config config)
       : _config = config,
         _authorizationRequest = AuthorizationRequest(config) {
     _onCodeStream = _onCodeListener.stream.asBroadcastStream();
   }
-  Future<String /*?*/ > requestCode() async {
-    String /*?*/ code;
+  Future<String?> requestCode() async {
+    String? code;
     final urlParams = _constructUrlParams();
 
     await _webView.launch(
-      Uri.encodeFull('${_authorizationRequest.url}?$urlParams'),
+      '${_authorizationRequest.url}?$urlParams',
       clearCookies: _authorizationRequest.clearCookies,
       hidden: false,
       rect: _config.screenSize,
@@ -47,7 +47,7 @@ class RequestCode {
   }
 
   void sizeChanged() {
-    _webView.resize(_config.screenSize);
+    _webView.resize(_config.screenSize!);
   }
 
   Future<void> clearCookies() async {
@@ -57,7 +57,7 @@ class RequestCode {
     await _webView.close();
   }
 
-  Stream<String> get _onCode => _onCodeStream;
+  Stream<String?> get _onCode => _onCodeStream;
 
   String _constructUrlParams() =>
       _mapToQueryParams(_authorizationRequest.parameters);

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -7,16 +7,17 @@ class RequestCode {
   final StreamController<String> _onCodeListener = StreamController();
   final FlutterWebviewPlugin _webView = FlutterWebviewPlugin();
   final Config _config;
-  AuthorizationRequest _authorizationRequest;
+  final AuthorizationRequest _authorizationRequest;
 
-  var _onCodeStream;
+  /*late */ Stream<String> _onCodeStream;
 
-  RequestCode(Config config) : _config = config {
-    _authorizationRequest = AuthorizationRequest(config);
+  RequestCode(Config config)
+      : _config = config,
+        _authorizationRequest = AuthorizationRequest(config) {
+    _onCodeStream = _onCodeListener.stream.asBroadcastStream();
   }
-
-  Future<String> requestCode() async {
-    String code;
+  Future<String /*?*/ > requestCode() async {
+    String /*?*/ code;
     final urlParams = _constructUrlParams();
 
     await _webView.launch(
@@ -56,16 +57,15 @@ class RequestCode {
     await _webView.close();
   }
 
-  Stream<String> get _onCode =>
-      _onCodeStream ??= _onCodeListener.stream.asBroadcastStream();
+  Stream<String> get _onCode => _onCodeStream;
 
   String _constructUrlParams() =>
       _mapToQueryParams(_authorizationRequest.parameters);
 
   String _mapToQueryParams(Map<String, String> params) {
     final queryParams = <String>[];
-    params
-        .forEach((String key, String value) => queryParams.add('$key=$value'));
+    params.forEach((String key, String value) =>
+        queryParams.add('$key=${Uri.encodeQueryComponent(value)}'));
     return queryParams.join('&');
   }
 }

--- a/lib/request_token.dart
+++ b/lib/request_token.dart
@@ -17,7 +17,7 @@ class RequestToken {
         _tokenRequest.url, _tokenRequest.params, _tokenRequest.headers);
   }
 
-  Future<Token> requestRefreshToken(String/*!*/ refreshToken) async {
+  Future<Token> requestRefreshToken(String refreshToken) async {
     final _tokenRefreshRequest =
         TokenRefreshRequestDetails(config, refreshToken);
     return await _sendTokenRequest(_tokenRefreshRequest.url,

--- a/lib/request_token.dart
+++ b/lib/request_token.dart
@@ -8,19 +8,18 @@ import 'model/token.dart';
 
 class RequestToken {
   final Config config;
-  TokenRequestDetails _tokenRequest;
-  TokenRefreshRequestDetails _tokenRefreshRequest;
 
   RequestToken(this.config);
 
   Future<Token> requestToken(String code) async {
-    _generateTokenRequest(code);
+    final _tokenRequest = TokenRequestDetails(config, code);
     return await _sendTokenRequest(
         _tokenRequest.url, _tokenRequest.params, _tokenRequest.headers);
   }
 
-  Future<Token> requestRefreshToken(String refreshToken) async {
-    _generateTokenRefreshRequest(refreshToken);
+  Future<Token> requestRefreshToken(String/*!*/ refreshToken) async {
+    final _tokenRefreshRequest =
+        TokenRefreshRequestDetails(config, refreshToken);
     return await _sendTokenRequest(_tokenRefreshRequest.url,
         _tokenRefreshRequest.params, _tokenRefreshRequest.headers);
   }
@@ -28,16 +27,11 @@ class RequestToken {
   Future<Token> _sendTokenRequest(String url, Map<String, String> params,
       Map<String, String> headers) async {
     var response = await post(Uri.parse(url), body: params, headers: headers);
-    Map<String, dynamic> tokenJson = json.decode(response.body);
-    var token = Token.fromJson(tokenJson);
-    return token;
-  }
-
-  void _generateTokenRequest(String code) {
-    _tokenRequest = TokenRequestDetails(config, code);
-  }
-
-  void _generateTokenRefreshRequest(String refreshToken) {
-    _tokenRefreshRequest = TokenRefreshRequestDetails(config, refreshToken);
+    final tokenJson = json.decode(response.body);
+    if (tokenJson is Map<String, dynamic>) {
+      var token = Token.fromJson(tokenJson);
+      return token;
+    }
+    throw ArgumentError('Token json is invalid');
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   process:
     dependency: transitive
     description:
@@ -293,7 +293,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.4"
+    version: "2.2.5"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: aad_oauth
 description: A Flutter OAuth package for performing user authentication against
   Azure Active Directory OAuth2 v2.0 endpoint.
-version: 0.2.2
+version: 0.3.0
 homepage: https://github.com/Earlybyte/aad_oauth
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR migrates the library and samples to sound null safety and bumps the major version to 0.3.0 to resolve #105

API compatibility should be largely maintained  aside from null enforcement. I have tested (on Android only) with the example app, but not the example_b2c (aside from loading it on a phone as I don't have B2C in my directory to test).
