### PR TITLE
Multiple custom policies

### DIFF
--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -10,7 +10,7 @@ class Config {
   final String authorizationUrl;
 
   /// Azure AD token URL.
-  final String tokenUrl;
+  String tokenUrl;
 
   /// The tenant value in the path of the request can be used to control who can sign into the application.
   /// The allowed values are common, organizations, consumers, and tenant identifiers. Or Name of your Azure AD B2C tenant.
@@ -19,6 +19,9 @@ class Config {
   /// __AAD B2C only__: The user flow to be run. Specify the name of a user flow you've created in your Azure AD B2C tenant.
   /// For example: b2c_1_sign_in, b2c_1_sign_up, or b2c_1_edit_profile
   final String? policy;
+
+  /// List of other possible flows that the user can use
+  final List<String> otherPolicies;
 
   /// The Application (client) ID that the Azure portal – App registrations experience assigned to your app.
   final String clientId;
@@ -114,6 +117,7 @@ class Config {
   Config(
       {required this.tenant,
       this.policy,
+      this.otherPolicies = const <String>[],
       required this.clientId,
       this.responseType = 'code',
       required this.redirectUri,
@@ -138,4 +142,11 @@ class Config {
         tokenUrl = isB2C
             ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/token'
             : 'https://login.microsoftonline.com/$tenant/oauth2/v2.0/token';
+
+  void updatePolicyTokenUrl(String newPolicy) {
+    if (isB2C) {
+      tokenUrl =
+          'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$newPolicy/oauth2/v2.0/token';
+    }
+  }
 }

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -31,6 +31,17 @@ class RequestCode {
     _webView.onUrlChanged.listen((String url) {
       var uri = Uri.parse(url);
 
+      if (_config.otherPolicies.isNotEmpty) {
+        for (var policy in _config.otherPolicies) {
+          if (uri.pathSegments.contains('authorize')) {
+            if (uri.pathSegments.contains(policy)) {
+              _config.updatePolicyTokenUrl(policy);
+              break;
+            }
+          }
+        }
+      }
+
       if (uri.queryParameters['error'] != null) {
         _webView.close();
         _onCodeListener.add(null);

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -31,7 +31,7 @@ class RequestCode {
     _webView.onUrlChanged.listen((String url) {
       var uri = Uri.parse(url);
 
-      if (_config.otherPolicies.isNotEmpty) {
+      if (_config.otherPolicies.isNotEmpty && _config.isB2C) {
         for (var policy in _config.otherPolicies) {
           if (uri.pathSegments.contains('authorize')) {
             if (uri.pathSegments.contains(policy)) {


### PR DESCRIPTION
This PR is for b2c implementations that use multiple custom policies that can change within the browser
The implementation adds the otherPolicies field to the Config class and listens for url changes that occur in the browser, updating detailed description in this issue #136 