### PR TITLE
Fix login error when changing user password.

### DIFF
--- a/lib/helper/mobile_oauth.dart
+++ b/lib/helper/mobile_oauth.dart
@@ -69,7 +69,13 @@ class MobileOAuth extends CoreOAuth {
     }
 
     if (token.hasRefreshToken()) {
-      token = await _requestToken.requestRefreshToken(token.refreshToken!);
+      try {
+        token = await _requestToken.requestRefreshToken(token.refreshToken!);
+      } on ArgumentError {
+        //If refresh token request throws an exception, we have to do
+        //a fullAuthFlow.
+        token.accessToken = null;
+      }
     }
 
     if (!token.hasValidAccessToken()) {


### PR DESCRIPTION
If the token has expired and the user has changed his password, when the plugin tried to use the refresh token an exception was thrown.