### PR TITLE
Add AadAuthException to allow selective error handling

### DIFF
--- a/lib/model/aad_auth_exception.dart
+++ b/lib/model/aad_auth_exception.dart
@@ -1,0 +1,9 @@
+class AadAuthException implements Exception {
+  final String error;
+  final String? errorSubcode;
+
+  const AadAuthException({
+    required this.error,
+    this.errorSubcode,
+  });
+}

--- a/lib/request_code.dart
+++ b/lib/request_code.dart
@@ -1,15 +1,18 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 
-import 'request/authorization_request.dart';
-import 'model/config.dart';
+import 'package:aad_oauth/model/aad_auth_exception.dart';
+import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+
+import 'model/config.dart';
+import 'request/authorization_request.dart';
 
 class RequestCode {
   final Config _config;
   final AuthorizationRequest _authorizationRequest;
 
   String? _code;
+  Exception? _exception;
 
   RequestCode(Config config)
       : _config = config,
@@ -34,13 +37,24 @@ class RequestCode {
         )),
       ),
     );
+
+    final exception = _exception;
+    if (exception != null) {
+      throw exception;
+    }
+
     return _code;
   }
 
   FutureOr<NavigationDecision> _navigationDelegate(NavigationRequest request) {
     var uri = Uri.parse(request.url);
 
-    if (uri.queryParameters['error'] != null) {
+    final errorCode = uri.queryParameters['error'];
+    if (errorCode != null) {
+      _exception = AadAuthException(
+        error: errorCode,
+        errorSubcode: uri.queryParameters['error_subcode'],
+      );
       _config.navigatorKey.currentState!.pop();
     }
 


### PR DESCRIPTION
This PR allows selective error handling by library consumers.
It can be useful in f.e.: handling the back button on the login page:
```dart
try {
   await logIn();
} on AadAuthException catch (e) {
  if(e.errorSubcode == "cancel") {
    // User pressed back button on login page, do something
  } else {
    // Other error occurred, do something else
  }
}
```