### PR TITLE
Address #173 by adding support for web redirect auth flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+- Added web redirect authentication flow option [#173]
+  - Must use at least version 2.13.1 of MSAL library from MS in index.html
+  - Calculates an appropriate default redirect URI on mobile and web if not provided
 
 ## [0.4.1-beta.2] - 20220919
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Afterwards you must create a navigatorKey and initialize the library as follow:
     tenant: "YOUR_TENANT_ID",
     clientId: "YOUR_CLIENT_ID",
     scope: "openid profile offline_access",
+    // redirectUri is Optional as a default is calculated based on app type/web location
     redirectUri: "your redirect url available in azure portal",
     navigatorKey: navigatorKey,
+    webUseRedirect: true, // default is false - on web only, forces a redirect flow instead of popup auth
     //Optional parameter: Centered CircularProgressIndicator while rendering web page in WebView
     loader: Center(child: CircularProgressIndicator()),
   );
@@ -78,15 +80,23 @@ await oauth.logout();
 
 ### Web Usage
 
-For web you also have to add some lines to your `index.html`:
+For web you also have to add some lines to your `index.html` (see the `index.html` in the example applications):
 ```html
 <head>
-  <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.3.0/js/msal-browser.min.js"
-      integrity="sha384-o+Sncs5XJ3NEAeriM/FV8YGZrh7mZk4GfNutRTbYjsDNJxb7caCLeqiDabistgwW"
-      crossorigin="anonymous"></script>
+  <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.13.1/js/msal-browser.min.js"
+    integrity="sha384-2Vr9MyareT7qv+wLp1zBt78ZWB4aljfCTMUrml3/cxm0W81ahmDOC6uyNmmn0Vrc"
+    crossorigin="anonymous"></script>
   <script src="assets/packages/aad_oauth/assets/msalv2.js"></script>
 </head>
 ```
+
+Note that when using redirect flow on web, the `login()` call will not return if the user has not logged in yet because
+the page is redirected and the app is destroyed until login is complete. Your application must take care of calling
+`login()` again once reloaded to complete the login process within the flutter application - if login was successful,
+this second call will be fast, and will not cause another redirection.
+
+When using redirecting logins with the example application, you will need to click on the login button again following 
+a successful login to see the token details. 
 
 ### B2C Usage
 
@@ -105,7 +115,7 @@ Add your Azure tenant ID, tenantName, client ID (ID of App), client Secret (Secr
     tenant: "YOUR_TENANT_NAME",
     clientId: "YOUR_CLIENT_ID",
     scope: "YOUR_CLIENT_ID offline_access",
-    redirectUri: "https://login.live.com/oauth20_desktop.srf",
+    // redirectUri: "https://login.live.com/oauth20_desktop.srf", // Note: this is the default for Mobile
     clientSecret: "YOUR_CLIENT_SECRET",
     isB2C: true,
     policy: "YOUR_USER_FLOW___USER_FLOW_A",

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   async:
     dependency: transitive
     description:
@@ -96,21 +96,21 @@ packages:
       name: flutter_secure_storage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter_secure_storage_macos:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the
@@ -8,14 +9,14 @@
     The path provided below has to start and end with a slash "/" in order for
     it to work correctly.
 
-    For more details:
+    Fore more details:
     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
   -->
   <base href="/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="AAD OAUTH Example">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -23,80 +24,29 @@
   <meta name="apple-mobile-web-app-title" content="example">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
-  <title>example</title>
-  <link rel="manifest" href="manifest.json">
-  <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.3.0/js/msal-browser.min.js"
-    integrity="sha384-o+Sncs5XJ3NEAeriM/FV8YGZrh7mZk4GfNutRTbYjsDNJxb7caCLeqiDabistgwW"
+  <!-- Favicon 
+  <link rel="icon" type="image/png" href="favicon.png" />
+  -->
+  <title>AAD OAUTH Example</title>
+  <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.13.1/js/msal-browser.min.js"
+    integrity="sha384-2Vr9MyareT7qv+wLp1zBt78ZWB4aljfCTMUrml3/cxm0W81ahmDOC6uyNmmn0Vrc"
     crossorigin="anonymous"></script>
-  <script src="assets/packages/aad_oauth/assets/msalv2.js"></script>  
+  <script src="assets/packages/aad_oauth/assets/msalv2.js"></script>
+  <link rel="manifest" href="manifest.json">
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
-    var scriptLoaded = false;
-    function loadMainDartJs() {
-      if (scriptLoaded) {
-        return;
-      }
-      scriptLoaded = true;
-      var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
-      scriptTag.type = 'application/javascript';
-      document.body.append(scriptTag);
-    }
-
     if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
-                  console.log('Installed new service worker.');
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing ?? reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log('New service worker available.');
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
-              console.log('Loading app from service worker.');
-              loadMainDartJs();
-            }
-          });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plaint <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
+      window.addEventListener('flutter-first-frame', function () {
+        navigator.serviceWorker.register('flutter_service_worker.js');
       });
-    } else {
-      // Service workers not supported. Just drop the <script> tag.
-      loadMainDartJs();
     }
   </script>
+  <script src="main.dart.js" type="application/javascript"></script>
 </body>
+
 </html>

--- a/example_b2c/lib/main.dart
+++ b/example_b2c/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:aad_oauth/aad_oauth.dart';
 import 'package:aad_oauth/model/config.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(MyApp());
@@ -40,18 +39,10 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  // Must configure flutter to start the web server for the app on
-  // the port listed below. In VSCode, this can be done with
-  // the following run settings in launch.json
-  // "args": ["-d", "chrome","--web-port", "8483"]
-
   static final Config configB2Ca = Config(
       tenant: 'YOUR_TENANT_NAME',
       clientId: 'YOUR_CLIENT_ID',
       scope: 'YOUR_CLIENT_ID offline_access',
-      redirectUri: kIsWeb
-          ? 'http://localhost:8483'
-          : 'https://login.live.com/oauth20_desktop.srf',
       clientSecret: 'YOUR_CLIENT_SECRET',
       isB2C: true,
       navigatorKey: navigatorKey,
@@ -64,9 +55,6 @@ class _MyHomePageState extends State<MyHomePage> {
       clientId: 'YOUR_CLIENT_ID',
       scope: 'YOUR_CLIENT_ID offline_access',
       navigatorKey: navigatorKey,
-      redirectUri: kIsWeb
-          ? 'http://localhost:8483'
-          : 'https://login.live.com/oauth20_desktop.srf',
       clientSecret: 'YOUR_CLIENT_SECRET',
       isB2C: true,
       policy: 'YOUR_USER_FLOW___USER_FLOW_B',
@@ -150,12 +138,15 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   void login(AadOAuth oAuth) async {
-    try {
-      await oAuth.login();
-      final accessToken = await oAuth.getAccessToken();
-      showMessage('Logged in successfully, your access token: $accessToken');
-    } catch (e) {
-      showError(e);
+    final result = await oAuth.login();
+    result.fold(
+      (l) => showError(l.toString()),
+      (r) => showMessage('Logged in successfully, your access token: $r'),
+    );
+    var accessToken = await oAuth.getAccessToken();
+    if (accessToken != null) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(accessToken)));
     }
   }
 

--- a/example_b2c/web/index.html
+++ b/example_b2c/web/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the
@@ -8,14 +9,14 @@
     The path provided below has to start and end with a slash "/" in order for
     it to work correctly.
 
-    For more details:
+    Fore more details:
     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
   -->
   <base href="/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="AAD OAUTH B2C Example">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -23,80 +24,29 @@
   <meta name="apple-mobile-web-app-title" content="example_b2c">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
-  <title>example_b2c</title>
-  <link rel="manifest" href="manifest.json">
-  <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.3.0/js/msal-browser.min.js"
-    integrity="sha384-o+Sncs5XJ3NEAeriM/FV8YGZrh7mZk4GfNutRTbYjsDNJxb7caCLeqiDabistgwW"
+  <!-- Favicon 
+  <link rel="icon" type="image/png" href="favicon.png" />
+  -->
+  <title>AAD OAUTH B2C Example</title>
+  <script type="text/javascript" src="https://alcdn.msauth.net/browser/2.13.1/js/msal-browser.min.js"
+    integrity="sha384-2Vr9MyareT7qv+wLp1zBt78ZWB4aljfCTMUrml3/cxm0W81ahmDOC6uyNmmn0Vrc"
     crossorigin="anonymous"></script>
   <script src="assets/packages/aad_oauth/assets/msalv2.js"></script>
+  <link rel="manifest" href="manifest.json">
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
-    var scriptLoaded = false;
-    function loadMainDartJs() {
-      if (scriptLoaded) {
-        return;
-      }
-      scriptLoaded = true;
-      var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
-      scriptTag.type = 'application/javascript';
-      document.body.append(scriptTag);
-    }
-
     if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
-                  console.log('Installed new service worker.');
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing ?? reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log('New service worker available.');
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
-              console.log('Loading app from service worker.');
-              loadMainDartJs();
-            }
-          });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plaint <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
+      window.addEventListener('flutter-first-frame', function () {
+        navigator.serviceWorker.register('flutter_service_worker.js');
       });
-    } else {
-      // Service workers not supported. Just drop the <script> tag.
-      loadMainDartJs();
     }
   </script>
+  <script src="main.dart.js" type="application/javascript"></script>
 </body>
+
 </html>

--- a/lib/helper/web_oauth.dart
+++ b/lib/helper/web_oauth.dart
@@ -18,6 +18,7 @@ external void jsInit(MsalConfig config);
 @JS('login')
 external void jsLogin(
   bool refreshIfAvailable,
+  bool useRedirect,
   void Function(dynamic) onSuccess,
   void Function(dynamic) onError,
 );
@@ -35,7 +36,8 @@ external String? jsGetAccessToken();
 external String? jsGetIdToken();
 
 class WebOAuth extends CoreOAuth {
-  WebOAuth(Config config) {
+  final Config config;
+  WebOAuth(this.config) {
     jsInit(MsalConfig.construct(
         tenant: config.tenant,
         policy: config.policy,
@@ -77,6 +79,7 @@ class WebOAuth extends CoreOAuth {
 
     jsLogin(
       refreshIfAvailable,
+      config.webUseRedirect,
       allowInterop(
           (_value) => completer.complete(Right(Token(accessToken: _value)))),
       allowInterop((_error) => completer.complete(Left(AadOauthFailure(


### PR DESCRIPTION
This PR addresses #173 by adding a non-default option for redirect auth flows to flutter web apps.

This resolves an issue with being completely unable to login on iOS devices with home-screen installed PWAs made from a flutter app due to the authentication popup and the PWA web sandbox being isolated from each other.

It is possible to change the type of authentication by changing the option in the configuration after it is created.

My testing showed that an update to the MSAL library is required for this patch to work with the example application.

When using redirect flow, it is important to call login() again after the application is reloaded, following the completion
of the redirect authentication flow, or the token acquisition will not have been completed. If the application triggers a `login()`
whenever it first loads to acquire a token, this will be transparent to the user.


Closes #173

Closes #171