### PR TITLE
add origin header for mobile token request

### DIFF
--- a/lib/request/token_refresh_request.dart
+++ b/lib/request/token_refresh_request.dart
@@ -16,7 +16,8 @@ class TokenRefreshRequestDetails {
         },
         headers = {
           'Accept': 'application/json',
-          'Content-Type': Config.contentType
+          'Content-Type': Config.contentType,
+          'Origin': '',
         } {
     if (config.clientSecret != null) {
       params.putIfAbsent('client_secret', () => config.clientSecret!);

--- a/lib/request/token_request.dart
+++ b/lib/request/token_request.dart
@@ -16,7 +16,8 @@ class TokenRequestDetails {
         },
         headers = {
           'Accept': 'application/json',
-          'Content-Type': Config.contentType
+          'Content-Type': Config.contentType,
+          'Origin': '',
         } {
     if (config.resource != null) {
       params.putIfAbsent('resource', () => config.resource!);


### PR DESCRIPTION
There is known aad issue - https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/2482#issuecomment-728275719.

I get an exception for mobile platforms - `Error during token request: invalid_request: AADSTS9002327: Tokens issued for the 'Single-Page Application' client-type may only be redeemed via cross-origin requests.`.

Its appears on:
Android 11 - OnePlus A6000
Android 10 - Huawei P30 Pro 
iOS 16.0.3 - iPhone SE

To fix this, it's needed to add `Origin` header to token request.

My temporary workaround is to add interceptor and wrap `login` method with intercepted client:

```
class AuthInterceptor implements InterceptorContract {
  @override
  Future<RequestData> interceptRequest({required RequestData data}) async {
    if (data.url.endsWith('/oauth2/v2.0/token') &&
        !data.headers.containsKey('Origin')) {
      data.headers.addAll({'Origin': ''});
    }
    return data;
  }
}

class AuthService {
  final _client = InterceptedClient.build(
    interceptors: [
      AuthInterceptor(),
    ],
  );

  Future<void> login() {
    return runWithClient(
      () => oauth.login(refreshIfAvailable: true),
      () => _client,
    );
  }
}

```