### PR TITLE
Add Azure B2C support for Flutter Web

### DIFF
--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -17,7 +17,7 @@ var aadOauth = (function () {
     var msalConfig = {
       auth: {
         clientId: config.clientId,
-        authority: "https://login.microsoftonline.com/" + config.tenant,
+        authority: config.isB2C ? "https://" + config.tenant + ".b2clogin.com/" + config.tenant + ".onmicrosoft.com/" + config.policy + "/" : "https://login.microsoftonline.com/" + config.tenant,
         redirectUri: config.redirectUri,
       },
       cache: {

--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -13,7 +13,7 @@ var aadOauth = (function () {
 
   // Initialise the myMSALObj for the given client, authority and scope
   function init(config) {
-    // TODO: Add support for other MSAL / B2C configuration
+    // TODO: Add support for other MSAL configuration
     var msalConfig = {
       auth: {
         clientId: config.clientId,


### PR DESCRIPTION
This pull request fixes issue #200. The msalv2.js platform code always called Microsoft's standard login flow, even if isB2C = true.

With the fix, msalv2.js will now correctly launch the request Azure B2C login flow if isB2C = true.