### PR TITLE
Refresh authResult from cache in getAccessToken and getIdToken

### DIFF
--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -116,6 +116,8 @@ var aadOauth = (function () {
       return
     }
 
+    const account = getAccount()
+      
     if (useRedirect) {
       myMSALObj.acquireTokenRedirect({
         scopes: tokenRequest.scopes,
@@ -125,8 +127,6 @@ var aadOauth = (function () {
       });
     } else {
       // Sign in with popup
-      const account = getAccount()
-      
       try {        
         const interactiveAuthResult = await myMSALObj.loginPopup({
           scopes: tokenRequest.scopes,

--- a/assets/msalv2.js
+++ b/assets/msalv2.js
@@ -173,11 +173,51 @@ var aadOauth = (function () {
       .catch(onError);
   }
 
-  function getAccessToken() {
+  async function getAccessToken() {
+    const account = getAccount();
+
+    if (account !== null && authResult === null) {
+      try {
+        // Silent acquisition only works if we the access token is either
+        // within its lifetime, or the refresh token can successfully be
+        // used to refresh it. This will throw if the access token can't
+        // be acquired.
+        const silentAuthResult = await myMSALObj.acquireTokenSilent({
+          scopes: tokenRequest.scopes,
+          prompt: "none",
+          account: account,
+          extraQueryParameters: tokenRequest.extraQueryParameters
+        });
+
+        authResult = silentAuthResult
+      } catch (_) {
+      }
+    }
+
     return authResult ? authResult.accessToken : null;
   }
 
-  function getIdToken() {
+  async function getIdToken() {
+    const account = getAccount();
+
+    if (account !== null && authResult === null) {
+      try {
+        // Silent acquisition only works if we the access token is either
+        // within its lifetime, or the refresh token can successfully be
+        // used to refresh it. This will throw if the access token can't
+        // be acquired.
+        const silentAuthResult = await myMSALObj.acquireTokenSilent({
+          scopes: tokenRequest.scopes,
+          prompt: "none",
+          account: account,
+          extraQueryParameters: tokenRequest.extraQueryParameters
+        });
+
+        authResult = silentAuthResult
+      } catch (_) {
+      }
+    }
+
     return authResult ? authResult.idToken : null;
   }
 

--- a/lib/helper/web_oauth.dart
+++ b/lib/helper/web_oauth.dart
@@ -12,6 +12,7 @@ import 'package:aad_oauth/model/msalconfig.dart';
 import 'package:aad_oauth/model/token.dart';
 import 'package:dartz/dartz.dart';
 import 'package:js/js.dart';
+import 'package:js/js_util.dart';
 
 @JS('init')
 external void jsInit(MsalConfig config);
@@ -31,10 +32,10 @@ external void jsLogout(
 );
 
 @JS('getAccessToken')
-external String? jsGetAccessToken();
+external Object jsGetAccessToken();
 
 @JS('getIdToken')
-external String? jsGetIdToken();
+external Object jsGetIdToken();
 
 class WebOAuth extends CoreOAuth {
   final Config config;
@@ -66,12 +67,12 @@ class WebOAuth extends CoreOAuth {
 
   @override
   Future<String?> getAccessToken() async {
-    return jsGetAccessToken();
+    return promiseToFuture(jsGetAccessToken());
   }
 
   @override
   Future<String?> getIdToken() async {
-    return jsGetIdToken();
+    return promiseToFuture(jsGetIdToken());
   }
 
   @override


### PR DESCRIPTION
This PR addresses issue #214 by trying to retrieve tokens from the cache before returning null. authResult will always be null on page reload, which renders getAccessToken() and getIdToken() inoperable unless calling login() before using them.

However, MSAL supports token caching and aad_oauth explicitly sets localStorage as cache mechanism.

This PR ensures that the cache will always be used.