### PR TITLE
Added custom domain url with tenant Id for B2C with Azure Front Door

### DIFF
--- a/lib/model/config.dart
+++ b/lib/model/config.dart
@@ -112,6 +112,13 @@ class Config {
   /// Azure Active Directory B2C provides business-to-customer identity as a service.
   final bool isB2C;
 
+  /// When using Azure AD B2C with a custom domain or Azure Front Door, 
+  /// the custom domain URL must be used instead of the default login.microsoftonline.com URL.
+  /// This will change the issuer of the token to the custom domain URL.
+  /// Example: https://account.examplecompany.com/01234567-89ab-cdef-0123-456789abcdef.
+  /// More information can be found here: https://learn.microsoft.com/en-us/azure/active-directory-b2c/custom-domain.
+  final String? customDomainUrlWithTenantId;
+
   /// Flag whether to use a stub implementation for unit testing or not
   bool isStub;
 
@@ -186,6 +193,7 @@ class Config {
     this.clientSecret,
     this.resource,
     this.isB2C = false,
+    this.customDomainUrlWithTenantId,
     this.loginHint,
     this.domainHint,
     this.codeVerifier,
@@ -199,10 +207,14 @@ class Config {
     this.customParameters = const {},
     String? postLogoutRedirectUri,
   })  : authorizationUrl = isB2C
-            ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/authorize'
+            ? (customDomainUrlWithTenantId == null 
+              ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/authorize'
+              : '$customDomainUrlWithTenantId/$policy/oauth2/v2.0/authorize')
             : 'https://login.microsoftonline.com/$tenant/oauth2/v2.0/authorize',
         tokenUrl = isB2C
-            ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/token'
+            ? (customDomainUrlWithTenantId == null
+              ? 'https://$tenant.b2clogin.com/$tenant.onmicrosoft.com/$policy/oauth2/v2.0/token'
+              : '$customDomainUrlWithTenantId/$policy/oauth2/v2.0/token')
             : 'https://login.microsoftonline.com/$tenant/oauth2/v2.0/token',
         postLogoutRedirectUri = postLogoutRedirectUri,
         aOptions = aOptions ?? AndroidOptions(encryptedSharedPreferences: true),


### PR DESCRIPTION
A while ago @ivanovgeorgi made a pull request #141 for Azure B2C authentication with [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview). 
Azure Front Door with Azure B2C helps to remove the Microsoft branding of the url and specify it to a custom domain. 

When using front door, the issuer of the JWT is changed to the new custom domain.
Verifying this token with the b2clogin.com issuer will fail. 

This commit will add functionality for a custom domain with tenant id to fully remove the Microsoft branding from the url and issuer. The field customDomainUrlWithTenantId is optional and will only be used when specified in the config, and if the b2c flag is set to true. All previously made configs will still work.

More information about Azure Front Door, custom domains and using a tenant id instead of the name can be found here:
https://learn.microsoft.com/en-us/azure/active-directory-b2c/custom-domain