### PR TITLE
Fix/inline linter rules to prevent conflict

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,30 +1,90 @@
-# This file configures the static analysis results for your project (errors,
-# warnings, and lints).
-#
-# This enables the 'recommended' set of lints from `package:lints`.
-# This set helps identify many issues that may lead to problems when running
-# or consuming Dart code, and enforces writing Dart using a single, idiomatic
-# style and format.
-#
-# If you want a smaller set of lints you can change this to specify
-# 'package:lints/core.yaml'. These are just the most critical lints
-# (the recommended set includes the core lints).
-# The core lints are also what is used by pub.dev for scoring packages.
-
-include: package:lints/recommended.yaml
-
-# Uncomment the following section to specify additional rules.
-
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
-
-# For more information about the core and recommended set of lints, see
-# https://dart.dev/go/core-lints
-
-# For additional information about configuring this file, see
-# https://dart.dev/guides/language/analysis-options
+linter:
+  rules:
+    - avoid_empty_else
+    - avoid_relative_lib_imports
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - collection_methods_unrelated_type
+    - curly_braces_in_flow_control_structures
+    - dangling_library_doc_comments
+    - depend_on_referenced_packages
+    - empty_catches
+    - file_names
+    - hash_and_equals
+    - implicit_call_tearoffs
+    - no_duplicate_case_values
+    - no_wildcard_variable_uses
+    - non_constant_identifier_names
+    - null_check_on_nullable_type_parameter
+    - package_prefixed_library_names
+    - prefer_generic_function_type_aliases
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
+    - secure_pubspec_urls
+    - type_literal_in_constant_pattern
+    - unnecessary_overrides
+    - unrelated_type_equality_checks
+    - use_string_in_part_of_directives
+    - valid_regexps
+    - void_checks
+    - annotate_overrides
+    - avoid_function_literals_in_foreach_calls
+    - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    - avoid_returning_null_for_void
+    - avoid_single_cascade_in_expression_statements
+    - constant_identifier_names
+    - control_flow_in_finally
+    - empty_constructor_bodies
+    - empty_statements
+    - exhaustive_cases
+    - implementation_imports
+    - library_names
+    - library_prefixes
+    - library_private_types_in_public_api
+    - no_leading_underscores_for_library_prefixes
+    - no_leading_underscores_for_local_identifiers
+    - null_closures
+    - overridden_fields
+    - package_names
+    - prefer_adjacent_string_concatenation
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_contains
+    - prefer_final_fields
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_function_declarations_over_variables
+    - prefer_if_null_operators
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    - prefer_interpolation_to_compose_strings
+    - prefer_is_not_operator
+    - prefer_null_aware_operators
+    - prefer_spread_collections
+    - recursive_getters
+    - slash_for_doc_comments
+    - type_init_formals
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_constructor_name
+    - unnecessary_getters_setters
+    - unnecessary_late
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
+    - unnecessary_this
+    - unnecessary_to_list_in_spreads
+    - use_function_type_syntax_for_parameters
+    - use_rethrow_when_possible
+    - use_super_parameters

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -113,7 +113,8 @@ class _MyHomePageState extends State<MyHomePage> {
     var accessToken = await oauth.getAccessToken();
     if (accessToken != null) {
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(accessToken)));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(accessToken)));
     }
   }
 
@@ -122,7 +123,8 @@ class _MyHomePageState extends State<MyHomePage> {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
+        content:
+            Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,7 +26,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
+  MyHomePage({super.key, required this.title});
   final String title;
 
   @override
@@ -113,8 +113,7 @@ class _MyHomePageState extends State<MyHomePage> {
     var accessToken = await oauth.getAccessToken();
     if (accessToken != null) {
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(accessToken)));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(accessToken)));
     }
   }
 
@@ -123,8 +122,7 @@ class _MyHomePageState extends State<MyHomePage> {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content:
-            Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
+        content: Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
       ),
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.4"
+    version: "1.0.0"
   async:
     dependency: transitive
     description:
@@ -97,10 +97,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage
-      sha256: "98352186ee7ad3639ccc77ad7924b773ff6883076ab952437d20f18a61f0a7c5"
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -137,10 +137,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: fc2910ec9b28d60598216c29ea763b3a96c401f0ce1d13cdf69ccb0e5c93c3ee
+      sha256: "5809c66f9dd3b4b93b0a6e2e8561539405322ee767ac2f64d084e2ab5429d108"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -171,10 +171,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   matcher:
     dependency: transitive
     description:
@@ -207,6 +207,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "3087813781ab814e4157b172f1a11c46be20179fcc9bea043e0fba36bc0acaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.15"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "2cec049d282c7f13c594b4a73976b0b4f2d7a1838a6dd5aaf7bd9719196bee86"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.27"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "916731ccbdce44d545414dd9961f26ba5fbaa74bcbb55237d8e65a623a8c7297"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
   path_provider_linux:
     dependency: transitive
     description:
@@ -227,18 +251,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: bcabbe399d4042b8ee687e17548d5d3f527255253b4a639f5f8d2094a9c2b45c
+      sha256: "1cb68ba4cd3a795033de62ba1b7b4564dace301f952de6bfb3cd91b202b6ee96"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
+    version: "2.1.7"
   platform:
     dependency: transitive
     description:
@@ -267,10 +283,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: "0344316c947ffeb3a529eac929e1978fcd37c26be4e8468628bac399365a3ca1"
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -400,42 +416,42 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter
-      sha256: "789d52bd789373cc1e100fb634af2127e86c99cf9abde09499743270c5de8d00"
+      sha256: c1ab9b81090705c6069197d9fdc1625e587b52b8d70cdde2339d177ad0dbb98e
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.4.1"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: da98c8cdaebea4cf89481853f37ca93ccc8d31fc386f5b3c928aea3b6e83268c
+      sha256: b0cd33dd7d3dd8e5f664e11a19e17ba12c352647269921a3b568406b001f1dff
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.12.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: "78715dc442b7849dbde74e92bb67de1cecf5addf95531c5fb474e72f5fe9a507"
+      sha256: "6d9213c65f1060116757a7c473247c60f3f7f332cac33dc417c9e362a9a13e4f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.6.0"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: dcd9ad0ef0f608f399d7a54d0b289597385e59a89f04983a672b9348faddfd98
+      sha256: b4b42295b3aa91ed22ba6d3dd7de56efbb8f3ab3d6e41d8b1615d13537c7801d
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.9.2"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      sha256: "7dacfda1edcca378031db9905ad7d7bd56b29fd1a90b0908b71a52a12c41e36b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "5.0.3"
   xdg_directories:
     dependency: transitive
     description:
@@ -446,4 +462,4 @@ packages:
     version: "1.0.0"
 sdks:
   dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.7.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   aad_oauth:

--- a/example_b2c/lib/main.dart
+++ b/example_b2c/lib/main.dart
@@ -31,7 +31,7 @@ class _MyAppState extends State<MyApp> {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
+  MyHomePage({super.key, required this.title});
   final String title;
 
   @override
@@ -198,8 +198,7 @@ class _MyHomePageState extends State<MyHomePage> {
     var accessToken = await oAuth.getAccessToken();
     if (accessToken != null) {
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(accessToken)));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(accessToken)));
     }
   }
 
@@ -208,8 +207,7 @@ class _MyHomePageState extends State<MyHomePage> {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content:
-            Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
+        content: Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
       ),
     );
   }

--- a/example_b2c/lib/main.dart
+++ b/example_b2c/lib/main.dart
@@ -198,7 +198,8 @@ class _MyHomePageState extends State<MyHomePage> {
     var accessToken = await oAuth.getAccessToken();
     if (accessToken != null) {
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(accessToken)));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(accessToken)));
     }
   }
 
@@ -207,7 +208,8 @@ class _MyHomePageState extends State<MyHomePage> {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
+        content:
+            Text('HasCachedAccountInformation: $hasCachedAccountInformation'),
       ),
     );
   }

--- a/example_b2c/lib/main.dart
+++ b/example_b2c/lib/main.dart
@@ -8,7 +8,7 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 class MyApp extends StatefulWidget {
   @override
-  _MyAppState createState() => _MyAppState();
+  State<MyApp> createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -35,7 +35,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/example_b2c/pubspec.yaml
+++ b/example_b2c/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   aad_oauth:

--- a/lib/helper/core_oauth.dart
+++ b/lib/helper/core_oauth.dart
@@ -13,22 +13,24 @@ class CoreOAuth {
 
   Future<Either<Failure, Token>> login(
           {bool refreshIfAvailable = false}) async =>
-      throw UnsupportedFailure(ErrorType.unsupported, 'Unsupported login');
+      throw UnsupportedFailure(
+          errorType: ErrorType.unsupported, message: 'Unsupported login');
 
   Future<Either<Failure, Token>> refreshToken() async =>
       throw UnsupportedFailure(
-          ErrorType.unsupported, 'Unsupported silentlyLogin');
+          errorType: ErrorType.unsupported,
+          message: 'Unsupported silentlyLogin');
 
-  Future<void> logout() async =>
-      throw UnsupportedFailure(ErrorType.unsupported, 'Unsupported logout');
+  Future<void> logout() async => throw UnsupportedFailure(
+      errorType: ErrorType.unsupported, message: 'Unsupported logout');
 
   Future<bool> get hasCachedAccountInformation async => false;
 
   Future<String?> getAccessToken() async => throw UnsupportedFailure(
-      ErrorType.unsupported, 'Unsupported getAccessToken');
+      errorType: ErrorType.unsupported, message: 'Unsupported getAccessToken');
 
   Future<String?> getIdToken() async => throw UnsupportedFailure(
-      ErrorType.unsupported, 'Unsupported getAccessToken');
+      errorType: ErrorType.unsupported, message: 'Unsupported getAccessToken');
 
   factory CoreOAuth.fromConfig(Config config) =>
       config.isStub ? MockCoreOAuth() : getOAuthConfig(config);

--- a/lib/helper/core_oauth.dart
+++ b/lib/helper/core_oauth.dart
@@ -21,8 +21,9 @@ class CoreOAuth {
           errorType: ErrorType.unsupported,
           message: 'Unsupported silentlyLogin');
 
-  Future<void> logout() async => throw UnsupportedFailure(
-      errorType: ErrorType.unsupported, message: 'Unsupported logout');
+  Future<void> logout({bool showPopup = true}) async =>
+      throw UnsupportedFailure(
+          errorType: ErrorType.unsupported, message: 'Unsupported logout');
 
   Future<bool> get hasCachedAccountInformation async => false;
 

--- a/lib/helper/mobile_oauth.dart
+++ b/lib/helper/mobile_oauth.dart
@@ -160,8 +160,8 @@ class MobileOAuth extends CoreOAuth {
     var code = await _requestCode.requestCode();
     if (code == null) {
       return Left(AadOauthFailure(
-        ErrorType.accessDeniedOrAuthenticationCanceled,
-        'Access denied or authentication canceled.',
+        errorType: ErrorType.accessDeniedOrAuthenticationCanceled,
+        message: 'Access denied or authentication canceled.',
       ));
     }
     return await _requestToken.requestToken(code);

--- a/lib/helper/web_oauth.dart
+++ b/lib/helper/web_oauth.dart
@@ -104,8 +104,9 @@ class WebOAuth extends CoreOAuth {
       allowInterop(
           (value) => completer.complete(Right(Token(accessToken: value)))),
       allowInterop((error) => completer.complete(Left(AadOauthFailure(
-            ErrorType.accessDeniedOrAuthenticationCanceled,
-            'Access denied or authentication canceled. Error: ${error.toString()}',
+            errorType: ErrorType.accessDeniedOrAuthenticationCanceled,
+            message:
+                'Access denied or authentication canceled. Error: ${error.toString()}',
           )))),
     );
 
@@ -120,8 +121,9 @@ class WebOAuth extends CoreOAuth {
       allowInterop(
           (value) => completer.complete(Right(Token(accessToken: value)))),
       allowInterop((error) => completer.complete(Left(AadOauthFailure(
-            ErrorType.accessDeniedOrAuthenticationCanceled,
-            'Access denied or authentication canceled. Error: ${error.toString()}',
+            errorType: ErrorType.accessDeniedOrAuthenticationCanceled,
+            message:
+                'Access denied or authentication canceled. Error: ${error.toString()}',
           )))),
     );
 

--- a/lib/model/failure.dart
+++ b/lib/model/failure.dart
@@ -11,7 +11,7 @@ abstract class Failure extends Equatable {
   final ErrorType errorType;
   final String message;
 
-  Failure(this.errorType, this.message);
+  Failure({required this.errorType, required this.message});
 
   @override
   List<Object> get props => [errorType, message];
@@ -21,13 +21,13 @@ abstract class Failure extends Equatable {
 }
 
 class RequestFailure extends Failure {
-  RequestFailure(errorType, message) : super(errorType, message);
+  RequestFailure({required super.errorType, required super.message});
 }
 
 class AadOauthFailure extends Failure {
-  AadOauthFailure(errorType, message) : super(errorType, message);
+  AadOauthFailure({required super.errorType, required super.message});
 }
 
 class UnsupportedFailure extends Failure {
-  UnsupportedFailure(errorType, message) : super(errorType, message);
+  UnsupportedFailure({required super.errorType, required super.message});
 }

--- a/lib/request_token.dart
+++ b/lib/request_token.dart
@@ -38,11 +38,12 @@ class RequestToken {
         var token = Token.fromJson(tokenJson);
         return Right(token);
       }
-      return Left(
-          RequestFailure(ErrorType.invalidJson, 'Token json is invalid'));
+      return Left(RequestFailure(
+          errorType: ErrorType.invalidJson, message: 'Token json is invalid'));
     } catch (e) {
       return Left(RequestFailure(
-          ErrorType.invalidJson, 'Token json is invalid: ${e.toString()}'));
+          errorType: ErrorType.invalidJson,
+          message: 'Token json is invalid: ${e.toString()}'));
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   webview_flutter: ^4.4.1 
   js: ^0.6.7 
   http: ^1.1.0 
-  lints: ^2.1.1
+
   shared_preferences: ^2.2.1
   dartz: ^0.10.1
   equatable: ^2.0.5


### PR DESCRIPTION
A fix for https://github.com/Earlybyte/aad_oauth/issues/275.

To prevent further issue of the sort I inlined the lint rules. The rules that were inlines are the rules of lints 3.0.0
Although this can add some extra work while upgrading the linting rules, it does set them in stone, and prevent further conflict as this package is getting more an more public attention.

I also took the extra steps to fix all the new lints rules. This translated in upgrading the example project to dart > 3.0.0, and minor modifications.
