### PR TITLE
Improve Example, specify Flutter Version constraint to 3.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Add the following to your pubspec.yaml dependencies:
 
 ```yaml
 dependencies:
-  aad_oauth: "^0.4.4"
+  aad_oauth: "^1.0.1"
 ```
 
 ## Contribution

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,9 +41,6 @@ class _MyHomePageState extends State<MyHomePage> {
     appBar: AppBar(
       title: Text('AAD OAuth Demo'),
     ),
-    onPageFinished: (String url) {
-      log('onPageFinished: $url');
-    },
   );
   final AadOAuth oauth = AadOAuth(config);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: aad_oauth
 description: A Flutter OAuth package for performing user authentication against
   Azure Active Directory OAuth2 v2.0 endpoint.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/Earlybyte/aad_oauth
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
-  flutter: ">=1.17.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.13.0" # Because of PopScope at least Flutter 3.13 is required to run aad_oauth >=1.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Instead of a white screen the action of the example will be to show the Token in an Alert Box again.